### PR TITLE
Clean up gitignore for Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,17 @@ venv.bak/
 .env
 .env.local
 .env.production
+.env.development
+.env.test
 
-# Logs6
-
+# Logs
 *.log
 logs/
+
+# Node
+**/node_modules/
+frontend/.next/
+frontend/out/
 
 # Database
 *.db
@@ -69,7 +75,7 @@ htmlcov/
 
 # Temporary files
 *.tmp
-*.temp 
+*.temp
 
 scripts/
 ai/


### PR DESCRIPTION
## Summary
- remove stray "Logs6" comment
- add Node build and environment ignores

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688b2501ca6c83279a899b5b2a05fa9f