### PR TITLE
feat: sync html language with i18n settings

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,8 @@ import { Noto_Sans_KR, Roboto } from 'next/font/google';
 import QueryProvider from '@/components/QueryProvider';
 import Sidebar from '@/components/Sidebar';
 import I18nProvider from '@/components/I18nProvider';
+import LanguageListener from '@/components/LanguageListener';
+import i18n from '@/i18n';
 import './globals.css';
 
 const notoSans = Noto_Sans_KR({
@@ -30,11 +32,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang={i18n.language}>
       <body
         className={`${notoSans.variable} ${roboto.variable} antialiased bg-gray-100`}
       >
         <I18nProvider>
+          <LanguageListener />
           <QueryProvider>
             <div className="flex h-screen">
               <Sidebar />

--- a/frontend/src/components/LanguageListener.tsx
+++ b/frontend/src/components/LanguageListener.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import i18n from '@/i18n';
+
+export default function LanguageListener() {
+  useEffect(() => {
+    const handleLanguageChange = (lng: string) => {
+      document.documentElement.lang = lng;
+    };
+
+    // Set initial language attribute
+    handleLanguageChange(i18n.language);
+
+    // Listen for language changes
+    i18n.on('languageChanged', handleLanguageChange);
+
+    return () => {
+      i18n.off('languageChanged', handleLanguageChange);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- use `i18n.language` to set `<html lang>`
- add `LanguageListener` to keep document language in sync with i18n changes

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to fetch `Roboto` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68945ff71fd88327be925a9fa0155434