### PR TITLE
feat: improve language switcher accessibility

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -2,16 +2,17 @@
 import { useTranslation } from 'react-i18next';
 
 export default function LanguageSwitcher() {
-  const { i18n } = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
 
   return (
     <select
+      aria-label={t('header.language')}
       className="bg-transparent border border-white rounded px-1 text-sm"
       value={i18n.language}
       onChange={(e) => i18n.changeLanguage(e.target.value)}
     >
-      <option value="en">EN</option>
-      <option value="ko">KO</option>
+      <option value="en">English</option>
+      <option value="ko">한국어</option>
     </select>
   );
 }


### PR DESCRIPTION
## Summary
- improve LanguageSwitcher accessibility with aria-label
- show full language names for clarity

## Testing
- `npm test` *(fails: Failed to fetch `Noto Sans KR` & `Roboto` from Google Fonts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689481981f048327b31cf3483f828e64