### PR TITLE
Localize accessibility controls

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -6,6 +6,9 @@
     "unreadAlerts": "{{count}} unread alerts",
     "user": "User",
     "toggleTheme": "Toggle theme",
+    "enableHighContrast": "Enable high contrast mode",
+    "disableHighContrast": "Disable high contrast mode",
+    "fontSize": "Base font size",
     "language": "Language",
     "datetime": "{{datetime}}",
     "userInfo": "{{username}} ({{role}})"

--- a/frontend/public/locales/ko/common.json
+++ b/frontend/public/locales/ko/common.json
@@ -6,6 +6,9 @@
     "unreadAlerts": "읽지 않은 알림 {{count}}개",
     "user": "사용자",
     "toggleTheme": "테마 전환",
+    "enableHighContrast": "고대비 모드 활성화",
+    "disableHighContrast": "고대비 모드 비활성화",
+    "fontSize": "기본 글꼴 크기",
     "language": "언어",
     "datetime": "{{datetime}}",
     "userInfo": "{{username}} ({{role}})"

--- a/frontend/src/components/FontSizeSelector.tsx
+++ b/frontend/src/components/FontSizeSelector.tsx
@@ -1,7 +1,9 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export default function FontSizeSelector() {
+  const { t } = useTranslation('common')
   const [fontSize, setFontSize] = useState<'small' | 'medium' | 'large'>(() => {
     if (typeof window === 'undefined') return 'medium'
     return (localStorage.getItem('fontSize') as 'small' | 'medium' | 'large') || 'medium'
@@ -18,7 +20,7 @@ export default function FontSizeSelector() {
     <select
       value={fontSize}
       onChange={e => setFontSize(e.target.value as 'small' | 'medium' | 'large')}
-      aria-label="Base font size"
+      aria-label={t('header.fontSize')}
       className="bg-input-bg rounded p-1 text-sm text-black focus:outline-none focus:ring-2 focus:ring-accent"
     >
       <option value="small">A-</option>

--- a/frontend/src/components/HighContrastToggle.tsx
+++ b/frontend/src/components/HighContrastToggle.tsx
@@ -1,8 +1,10 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from 'react-i18next'
 
 export default function HighContrastToggle() {
+  const { t } = useTranslation('common')
   const [mounted, setMounted] = useState(false)
   const [enabled, setEnabled] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false
@@ -31,7 +33,7 @@ export default function HighContrastToggle() {
       type="button"
       onClick={() => setEnabled(!enabled)}
       className="p-1 rounded hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-accent"
-      aria-label={enabled ? 'Disable high contrast mode' : 'Enable high contrast mode'}
+      aria-label={enabled ? t('header.disableHighContrast') : t('header.enableHighContrast')}
     >
       <AdjustmentsHorizontalIcon className="w-6 h-6" />
     </button>


### PR DESCRIPTION
## Summary
- internationalize high contrast and font size controls
- add i18n keys for high contrast toggle and font size selector

## Testing
- `npm test` *(fails: Failed to fetch font file)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894832557848327addd0ffef56012c5