### PR TITLE
feat: add logout logic in sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -111,7 +111,12 @@ export default function Sidebar() {
       <div className="px-4 py-4 border-t border-gray-800">
         <motion.button
           onClick={() => {
-            // TODO: 실제 로그아웃 로직 연결
+            if (typeof window !== 'undefined') {
+              localStorage.removeItem('token');
+              localStorage.removeItem('username');
+              // Optionally show confirmation toast
+              window.alert('Logged out');
+            }
             router.push('/login');
           }}
           className="group w-full flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400"


### PR DESCRIPTION
## Summary
- clear stored authentication data in sidebar logout handler
- navigate users to login screen with optional confirmation alert

## Testing
- `npm test` *(fails: Failed to fetch `Noto Sans KR` and `Roboto` fonts during build)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894856f6d0883278c25efe84cb25bfc