### PR TITLE
feat: localize alerts page

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -38,7 +38,9 @@
   },
   "filters": {
     "allPower": "All kW",
-    "allEquipment": "All Equipment"
+    "allEquipment": "All Equipment",
+    "power": "kW",
+    "equipment": "Equipment"
   },
   "status": {
     "normal": "Normal",
@@ -64,5 +66,37 @@
   "errorBoundary": {
     "message": "An error occurred",
     "retry": "Retry"
+  },
+  "alerts": {
+    "title": "Alerts",
+    "allSeverity": "All Severity",
+    "allStatus": "All Status",
+    "acknowledgeSelected": "Acknowledge Selected",
+    "clearSelected": "Clear Selected",
+    "headers": {
+      "time": "Time",
+      "kw": "kW",
+      "device": "Device",
+      "type": "Type",
+      "severity": "Severity",
+      "actions": "Actions"
+    },
+    "buttons": {
+      "acknowledge": "Acknowledge",
+      "clear": "Clear",
+      "details": "Details"
+    },
+    "noAlerts": "No alerts",
+    "filters": {
+      "severity": "Severity",
+      "startDate": "Start Date",
+      "endDate": "End Date",
+      "status": "Status"
+    },
+    "status": {
+      "new": "new",
+      "acknowledged": "acknowledged",
+      "cleared": "cleared"
+    }
   }
 }

--- a/frontend/public/locales/ko/common.json
+++ b/frontend/public/locales/ko/common.json
@@ -38,7 +38,9 @@
   },
   "filters": {
     "allPower": "모든 kW",
-    "allEquipment": "모든 장비"
+    "allEquipment": "모든 장비",
+    "power": "kW",
+    "equipment": "장비"
   },
   "status": {
     "normal": "정상",
@@ -64,5 +66,37 @@
   "errorBoundary": {
     "message": "문제가 발생했습니다",
     "retry": "다시 시도"
+  },
+  "alerts": {
+    "title": "알림",
+    "allSeverity": "모든 심각도",
+    "allStatus": "모든 상태",
+    "acknowledgeSelected": "선택 항목 확인",
+    "clearSelected": "선택 항목 삭제",
+    "headers": {
+      "time": "시간",
+      "kw": "kW",
+      "device": "장치",
+      "type": "유형",
+      "severity": "심각도",
+      "actions": "동작"
+    },
+    "buttons": {
+      "acknowledge": "확인",
+      "clear": "삭제",
+      "details": "세부 정보"
+    },
+    "noAlerts": "알림 없음",
+    "filters": {
+      "severity": "심각도",
+      "startDate": "시작 날짜",
+      "endDate": "종료 날짜",
+      "status": "상태"
+    },
+    "status": {
+      "new": "신규",
+      "acknowledged": "확인됨",
+      "cleared": "해결됨"
+    }
   }
 }

--- a/frontend/src/app/alerts/page.tsx
+++ b/frontend/src/app/alerts/page.tsx
@@ -9,6 +9,7 @@ import type { Machine } from '@/components/filters/EquipmentFilter'
 import { useQuery } from '@tanstack/react-query'
 import AlertDetailsModal from '@/components/AlertDetailsModal'
 import { error } from '@/lib/logger'
+import { useTranslation } from 'react-i18next'
 
 export default function AlertsPage() {
   const [alerts, setAlerts] = useState(alertList)
@@ -20,6 +21,7 @@ export default function AlertsPage() {
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const { t } = useTranslation('common')
 
   const { data: machines } = useQuery<Machine[]>({
     queryKey: ['machines'],
@@ -70,7 +72,7 @@ export default function AlertsPage() {
 
   return (
     <DashboardLayout>
-      <ChartCard title="Alerts">
+      <ChartCard title={t('alerts.title')}>
         <div className="flex flex-wrap gap-2 mb-2">
           <EquipmentFilter
             machines={machines ?? []}
@@ -83,8 +85,9 @@ export default function AlertsPage() {
             className="border rounded px-2 py-1"
             value={severity}
             onChange={(e) => setSeverity(e.target.value)}
+            aria-label={t('alerts.filters.severity')}
           >
-            <option value="">All Severity</option>
+            <option value="">{t('alerts.allSeverity')}</option>
             {severityOptions.map((opt) => (
               <option key={opt} value={opt}>
                 {opt}
@@ -96,22 +99,25 @@ export default function AlertsPage() {
             className="border rounded px-2 py-1"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
+            aria-label={t('alerts.filters.startDate')}
           />
           <input
             type="date"
             className="border rounded px-2 py-1"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
+            aria-label={t('alerts.filters.endDate')}
           />
           <select
             className="border rounded px-2 py-1"
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
+            aria-label={t('alerts.filters.status')}
           >
-            <option value="">All Status</option>
-            <option value="new">new</option>
-            <option value="acknowledged">acknowledged</option>
-            <option value="cleared">cleared</option>
+            <option value="">{t('alerts.allStatus')}</option>
+            <option value="new">{t('alerts.status.new')}</option>
+            <option value="acknowledged">{t('alerts.status.acknowledged')}</option>
+            <option value="cleared">{t('alerts.status.cleared')}</option>
           </select>
         </div>
         {selectedIds.length > 0 && (
@@ -123,7 +129,7 @@ export default function AlertsPage() {
                 setSelectedIds([])
               }}
             >
-              Acknowledge Selected
+              {t('alerts.acknowledgeSelected')}
             </button>
             <button
               className="px-2 py-1 bg-red-600 text-white rounded"
@@ -132,89 +138,91 @@ export default function AlertsPage() {
                 setSelectedIds([])
               }}
             >
-              Clear Selected
+              {t('alerts.clearSelected')}
             </button>
           </div>
         )}
-        <table className="w-full text-sm">
-          <thead className="text-left">
-            <tr>
-              <th className="py-2">
-                <input
-                  type="checkbox"
-                  checked={
-                    filteredAlerts.length > 0 &&
-                    filteredAlerts.every((a) => selectedIds.includes(a.id))
-                  }
-                  onChange={(e) => {
-                    if (e.target.checked) {
-                      setSelectedIds(filteredAlerts.map((a) => a.id))
-                    } else {
-                      setSelectedIds([])
-                    }
-                  }}
-                />
-              </th>
-              <th className="py-2">Time</th>
-              <th className="py-2">kW</th>
-              <th className="py-2">Device</th>
-              <th className="py-2">Type</th>
-              <th className="py-2">Severity</th>
-              <th className="py-2">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredAlerts.map((a) => (
-              <tr key={a.id} className="border-t">
-                <td className="py-2">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-left">
+              <tr>
+                <th className="py-2">
                   <input
                     type="checkbox"
-                    checked={selectedIds.includes(a.id)}
+                    checked={
+                      filteredAlerts.length > 0 &&
+                      filteredAlerts.every((a) => selectedIds.includes(a.id))
+                    }
                     onChange={(e) => {
                       if (e.target.checked) {
-                        setSelectedIds((prev) => [...prev, a.id])
+                        setSelectedIds(filteredAlerts.map((a) => a.id))
                       } else {
-                        setSelectedIds((prev) => prev.filter((id) => id !== a.id))
+                        setSelectedIds([])
                       }
                     }}
                   />
-                </td>
-                <td className="py-2">{a.time}</td>
-                <td className="py-2">{a.power}</td>
-                <td className="py-2">{a.device}</td>
-                <td className="py-2">{a.type}</td>
-                <td className="py-2">{a.severity}</td>
-                <td className="py-2 space-x-2">
-                  <button
-                    className="text-blue-600 underline"
-                    onClick={() => changeStatus(a.id, 'acknowledged')}
-                  >
-                    Acknowledge
-                  </button>
-                  <button
-                    className="text-red-600 underline"
-                    onClick={() => changeStatus(a.id, 'cleared')}
-                  >
-                    Clear
-                  </button>
-                  <button
-                    className="text-primary underline"
-                    onClick={() => setSelected(a)}
-                  >
-                    Details
-                  </button>
-                </td>
+                </th>
+                <th className="py-2">{t('alerts.headers.time')}</th>
+                <th className="py-2">{t('alerts.headers.kw')}</th>
+                <th className="py-2">{t('alerts.headers.device')}</th>
+                <th className="py-2">{t('alerts.headers.type')}</th>
+                <th className="py-2">{t('alerts.headers.severity')}</th>
+                <th className="py-2">{t('alerts.headers.actions')}</th>
               </tr>
-            ))}
-            {filteredAlerts.length === 0 && (
-              <tr>
-                <td className="py-2" colSpan={6}>
-                  No alerts
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {filteredAlerts.map((a) => (
+                <tr key={a.id} className="border-t">
+                  <td className="py-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.includes(a.id)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setSelectedIds((prev) => [...prev, a.id])
+                        } else {
+                          setSelectedIds((prev) => prev.filter((id) => id !== a.id))
+                        }
+                      }}
+                    />
+                  </td>
+                  <td className="py-2">{a.time}</td>
+                  <td className="py-2">{a.power}</td>
+                  <td className="py-2">{a.device}</td>
+                  <td className="py-2">{a.type}</td>
+                  <td className="py-2">{a.severity}</td>
+                  <td className="py-2 space-x-2">
+                    <button
+                      className="text-blue-600 underline"
+                      onClick={() => changeStatus(a.id, 'acknowledged')}
+                    >
+                      {t('alerts.buttons.acknowledge')}
+                    </button>
+                    <button
+                      className="text-red-600 underline"
+                      onClick={() => changeStatus(a.id, 'cleared')}
+                    >
+                      {t('alerts.buttons.clear')}
+                    </button>
+                    <button
+                      className="text-primary underline"
+                      onClick={() => setSelected(a)}
+                    >
+                      {t('alerts.buttons.details')}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {filteredAlerts.length === 0 && (
+                <tr>
+                  <td className="py-2" colSpan={6}>
+                    {t('alerts.noAlerts')}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </ChartCard>
       {selected && (
         <AlertDetailsModal alert={selected} onClose={() => setSelected(null)} />

--- a/frontend/src/components/filters/EquipmentFilter.tsx
+++ b/frontend/src/components/filters/EquipmentFilter.tsx
@@ -36,6 +36,7 @@ export default function EquipmentFilter({ machines, power, device, onPowerChange
           onPowerChange(e.target.value)
           onDeviceChange('')
         }}
+        aria-label={t('filters.power')}
       >
         <option value="">{t('filters.allPower')}</option>
         {powerOptions.map((opt) => (
@@ -48,6 +49,7 @@ export default function EquipmentFilter({ machines, power, device, onPowerChange
         className="border rounded px-2 py-1"
         value={device}
         onChange={(e) => onDeviceChange(e.target.value)}
+        aria-label={t('filters.equipment')}
       >
         <option value="">{t('filters.allEquipment')}</option>
         {deviceOptions.map((opt) => (


### PR DESCRIPTION
## Summary
- localize alerts page UI with translation keys
- label filter controls for accessibility
- improve mobile table usability

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to fetch `Noto Sans KR` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6894925c86a48327b63c38004b7ee489