### PR TITLE
Improve Help page with searchable FAQ and refined support links

### DIFF
--- a/frontend/src/__tests__/help.test.tsx
+++ b/frontend/src/__tests__/help.test.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import HelpPage from '@/app/help/page'
+
+jest.mock('@/components/DashboardLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/ChartCard', () => ({
+  __esModule: true,
+  default: ({ title, children }: { title: string; children: ReactNode }) => (
+    <div>
+      <h3>{title}</h3>
+      {children}
+    </div>
+  ),
+}))
+
+describe('Help page', () => {
+  it('filters FAQ items based on search', () => {
+    render(<HelpPage />)
+    expect(screen.getByText('How do I reset my password?')).toBeInTheDocument()
+    const input = screen.getByPlaceholderText('Search the FAQ...')
+    fireEvent.change(input, { target: { value: 'contact' } })
+    expect(screen.getByText('How do I contact support?')).toBeInTheDocument()
+    expect(
+      screen.queryByText('How do I reset my password?')
+    ).not.toBeInTheDocument()
+  })
+})
+

--- a/frontend/src/app/help/page.tsx
+++ b/frontend/src/app/help/page.tsx
@@ -1,22 +1,66 @@
 'use client'
 
+import { useState } from 'react'
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import DashboardLayout from '@/components/DashboardLayout'
 import ChartCard from '@/components/ChartCard'
 
+const faqs = [
+  {
+    question: 'How do I reset my password?',
+    answer: 'Go to Settings > Account and choose "Reset password".',
+  },
+  {
+    question: 'Where can I download reports?',
+    answer: 'Open the Reports page and use the Export button.',
+  },
+  {
+    question: 'How do I contact support?',
+    answer: 'Use the Email Support button or the Contact Form below.',
+  },
+]
+
 export default function HelpPage() {
+  const [query, setQuery] = useState('')
+
+  const filteredFaqs = faqs.filter(faq =>
+    faq.question.toLowerCase().includes(query.toLowerCase())
+  )
+
   return (
     <DashboardLayout>
       <div className="space-y-4">
-        <ChartCard title="Tooltips & Inline Help">
-          <p>
-            Hover over the
-            {' '}
-            <span title="This is a tooltip example" className="underline cursor-help">
-              highlighted text
-            </span>
-            {' '}to see a tooltip.
-          </p>
+        <ChartCard title="Search Help">
+          <div className="relative">
+            <MagnifyingGlassIcon className="absolute left-2 top-2.5 h-5 w-5 text-gray-500" />
+            <input
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search the FAQ..."
+              className="w-full pl-8 pr-2 py-2 border rounded bg-input-bg text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/50"
+            />
+          </div>
         </ChartCard>
+
+        <ChartCard title="Frequently Asked Questions">
+          <ul className="space-y-2">
+            {filteredFaqs.map(faq => (
+              <li key={faq.question}>
+                <details className="group">
+                  <summary className="cursor-pointer text-primary group-open:text-primary-hover">
+                    {faq.question}
+                  </summary>
+                  <p className="mt-2 text-gray-700">{faq.answer}</p>
+                </details>
+              </li>
+            ))}
+            {filteredFaqs.length === 0 && (
+              <li className="text-gray-500">No matches found.</li>
+            )}
+          </ul>
+        </ChartCard>
+
         <ChartCard title="Guides">
           <ul className="list-disc list-inside space-y-1">
             <li>
@@ -24,7 +68,7 @@ export default function HelpPage() {
                 href="https://example.com/guide.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 underline"
+                className="text-primary underline hover:text-primary-hover"
               >
                 PDF User Guide
               </a>
@@ -34,22 +78,39 @@ export default function HelpPage() {
                 href="https://example.com/tutorial.mp4"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 underline"
+                className="text-primary underline hover:text-primary-hover"
               >
                 Video Tutorial
               </a>
             </li>
           </ul>
         </ChartCard>
+
+        <ChartCard title="Tooltips & Inline Help">
+          <p>
+            Hover over the{' '}
+            <span
+              title="This is a tooltip example"
+              className="underline cursor-help text-primary"
+            >
+              highlighted text
+            </span>{' '}
+            to see a tooltip.
+          </p>
+        </ChartCard>
+
         <ChartCard title="Need Help?">
           <div className="space-x-2">
             <a
               href="mailto:support@example.com"
-              className="px-4 py-2 bg-primary text-white rounded"
+              className="px-4 py-2 bg-primary text-white rounded transition-colors hover:bg-primary-hover"
             >
               Email Support
             </a>
-            <a href="/contact" className="px-4 py-2 bg-accent text-white rounded">
+            <a
+              href="/contact"
+              className="px-4 py-2 bg-accent/90 text-gray-900 rounded transition-colors hover:bg-accent"
+            >
               Contact Form
             </a>
           </div>
@@ -58,3 +119,4 @@ export default function HelpPage() {
     </DashboardLayout>
   )
 }
+


### PR DESCRIPTION
## Summary
- Expand Help page with a searchable FAQ, resource guides, tooltip examples, and subtle styling.
- Add unit test verifying FAQ filtering logic.

## Testing
- `npm test` *(fails: Failed to fetch Noto Sans KR and Roboto fonts)*
- `npm run lint` *(fails: multiple pre-existing lint errors such as unexpected `any` types)*

------
https://chatgpt.com/codex/tasks/task_e_689d43a853c0832793c71c204094bf8d