### PR TITLE
feat: overhaul settings page

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -61,6 +61,53 @@
       "admin": "Admin",
       "operator": "Operator",
       "viewer": "Viewer"
+    },
+    "sections": {
+      "profile": "Profile & Account",
+      "notifications": "Notifications",
+      "security": "Security & Privacy",
+      "preferences": "App Preferences",
+      "advanced": "Advanced",
+      "about": "About & Help"
+    },
+    "search": "Search settings",
+    "save": "Save Changes",
+    "saved": "Settings saved",
+    "profile": {
+      "name": "Name",
+      "email": "Email",
+      "password": "Password",
+      "sns": "SNS Accounts",
+      "link": "Link",
+      "unlink": "Unlink"
+    },
+    "notifications": {
+      "push": "Push",
+      "email": "Email",
+      "sms": "SMS",
+      "frequency": "Frequency",
+      "daily": "Daily",
+      "weekly": "Weekly",
+      "monthly": "Monthly"
+    },
+    "security": {
+      "twoFactor": "Two-factor authentication",
+      "sessions": "Active sessions",
+      "logout": "Logout",
+      "download": "Download data",
+      "delete": "Delete account"
+    },
+    "preferences": {
+      "language": "Language",
+      "theme": "Theme"
+    },
+    "advanced": {
+      "beta": "Enable beta features",
+      "apiKey": "API Key",
+      "regenerate": "Regenerate"
+    },
+    "about": {
+      "version": "Version"
     }
   },
   "errorBoundary": {

--- a/frontend/public/locales/ko/common.json
+++ b/frontend/public/locales/ko/common.json
@@ -61,6 +61,53 @@
       "admin": "관리자",
       "operator": "운영자",
       "viewer": "뷰어"
+    },
+    "sections": {
+      "profile": "프로필/계정",
+      "notifications": "알림",
+      "security": "보안/프라이버시",
+      "preferences": "앱 환경",
+      "advanced": "고급",
+      "about": "버전 정보 & 도움말"
+    },
+    "search": "설정 검색",
+    "save": "저장",
+    "saved": "저장 완료",
+    "profile": {
+      "name": "이름",
+      "email": "이메일",
+      "password": "비밀번호",
+      "sns": "SNS 계정",
+      "link": "연결",
+      "unlink": "해제"
+    },
+    "notifications": {
+      "push": "푸시",
+      "email": "이메일",
+      "sms": "SMS",
+      "frequency": "알림 주기",
+      "daily": "일간",
+      "weekly": "주간",
+      "monthly": "월간"
+    },
+    "security": {
+      "twoFactor": "2단계 인증",
+      "sessions": "로그인한 기기",
+      "logout": "로그아웃",
+      "download": "데이터 다운로드",
+      "delete": "계정 삭제"
+    },
+    "preferences": {
+      "language": "언어",
+      "theme": "테마"
+    },
+    "advanced": {
+      "beta": "베타 기능 사용",
+      "apiKey": "API 키",
+      "regenerate": "재발급"
+    },
+    "about": {
+      "version": "버전"
     }
   },
   "errorBoundary": {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,13 +2,13 @@
 
 :root {
   --base-font-size: 16px;
-  --background: #ffffff;
-  --foreground: #171717;
-  --color-primary: 26 31 113;
-  --color-primary-hover: 0 95 115;
-  --color-accent: 242 201 76;
-  --color-input-bg: 245 245 220;
-  --color-text-primary: 55 65 81;
+  --background: #FFFFFF;
+  --foreground: #1C1C1E;
+  --color-primary: 58 110 165;
+  --color-primary-hover: 42 94 135;
+  --color-accent: 58 110 165;
+  --color-input-bg: 247 247 247;
+  --color-text-primary: 107 107 110;
   --chart-a: 167 107 95;
   --chart-ptr: 76 175 80;
   --chart-soa: 224 122 95;
@@ -49,9 +49,9 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
-    --color-primary: 26 31 113;
-    --color-primary-hover: 0 95 115;
-    --color-accent: 242 201 76;
+    --color-primary: 58 110 165;
+    --color-primary-hover: 42 94 135;
+    --color-accent: 58 110 165;
     --color-input-bg: 26 26 26;
     --color-text-primary: 229 231 235;
     --chart-a: 167 107 95;


### PR DESCRIPTION
## Summary
- revamp settings UI with sidebar navigation and category search
- add profile, notification, security, preference, advanced, and about sections
- update global color palette and translations

## Testing
- `npm test` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_689d485154ec83278d2487a35f5f3143