### PR TITLE
fix: improve card text visibility

### DIFF
--- a/frontend/src/components/SummaryCard.tsx
+++ b/frontend/src/components/SummaryCard.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 export default function SummaryCard({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="bg-gradient-to-r from-primary to-accent text-white rounded-lg shadow-md p-4 h-20 flex flex-col items-center justify-center">
+    <div className="bg-gradient-to-r from-primary to-accent text-slate-900 rounded-lg shadow-md p-4 h-20 flex flex-col items-center justify-center">
       <span className="text-sm opacity-90">{label}</span>
       <span className="text-2xl font-bold">{value}</span>
     </div>


### PR DESCRIPTION
## Summary
- ensure summary card text uses dark color for accessibility

## Testing
- `npm test` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*

------
https://chatgpt.com/codex/tasks/task_e_689d4c598a28832784f3c8547dfaae9a