### PR TITLE
fix: improve card and button text visibility

### DIFF
--- a/frontend/src/app/maintenance/page.tsx
+++ b/frontend/src/app/maintenance/page.tsx
@@ -122,7 +122,7 @@ export default function MaintenancePage() {
         <ChartCard title="Maintenance Notes">
           <div className="mb-2 text-right">
             <button
-              className="px-2 py-1 bg-primary text-white rounded"
+              className="px-2 py-1 bg-white border border-primary text-primary rounded"
               onClick={() => setShowModal(true)}
             >
               Add Note
@@ -202,7 +202,7 @@ export default function MaintenancePage() {
                 Cancel
               </button>
               <button
-                className="px-3 py-1 bg-primary text-white rounded"
+                className="px-3 py-1 bg-white border border-primary text-primary rounded disabled:opacity-50"
                 onClick={handleSave}
                 disabled={!noteEquipment || !noteDesc}
               >

--- a/frontend/src/components/SummaryCard.tsx
+++ b/frontend/src/components/SummaryCard.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 export default function SummaryCard({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="bg-gradient-to-r from-primary to-accent text-white rounded-lg shadow-md p-4 h-20 flex flex-col items-center justify-center">
+    <div className="bg-gradient-to-r from-primary to-accent text-slate-900 rounded-lg shadow-md p-4 h-20 flex flex-col items-center justify-center">
       <span className="text-sm opacity-90">{label}</span>
       <span className="text-2xl font-bold">{value}</span>
     </div>


### PR DESCRIPTION
## Summary
- ensure summary card text uses dark color for accessibility
- replace maintenance note buttons with primary-colored text on white background for clarity

## Testing
- `npm test` *(fails: Failed to fetch `Noto Sans KR` and `Roboto` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689d4c598a28832784f3c8547dfaae9a