### PR TITLE
feat(settings): add reset option

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -72,6 +72,7 @@
     "search": "Search settings",
     "save": "Save Changes",
     "saved": "Settings saved",
+    "reset": "Reset",
     "profile": {
       "name": "Name",
       "email": "Email",

--- a/frontend/public/locales/ko/common.json
+++ b/frontend/public/locales/ko/common.json
@@ -72,6 +72,7 @@
     "search": "설정 검색",
     "save": "저장",
     "saved": "저장 완료",
+    "reset": "초기화",
     "profile": {
       "name": "이름",
       "email": "이메일",

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -106,6 +106,28 @@ export default function SettingsPage() {
     setApiKey(key);
   };
 
+  const resetSettings = () => {
+    setName('');
+    setEmail('');
+    setPassword('');
+    setNotifications({ email: false, sms: false, push: false });
+    setFrequency('daily');
+    setTwoFactor(false);
+    setSessions(['Chrome on Windows']);
+    setLanguage('en');
+    setBeta(false);
+    const key = Math.random().toString(36).slice(2, 10);
+    setApiKey(key);
+    localStorage.removeItem('profile');
+    localStorage.removeItem('notifications');
+    localStorage.removeItem('notificationFrequency');
+    localStorage.removeItem('twoFactor');
+    localStorage.removeItem('sessions');
+    localStorage.removeItem('language');
+    localStorage.removeItem('beta');
+    localStorage.removeItem('apiKey');
+    setSaved(false);
+  };
   const logoutSession = (idx: number) => {
     setSessions(sessions.filter((_, i) => i !== idx));
   };
@@ -352,13 +374,22 @@ export default function SettingsPage() {
             </section>
           )}
 
-          <button
-            onClick={saveSettings}
-            className="px-4 py-2 bg-primary text-white rounded"
-            type="button"
-          >
-            {t('settings.save')}
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={resetSettings}
+              className="px-4 py-2 border border-primary text-primary rounded"
+              type="button"
+            >
+              {t('settings.reset')}
+            </button>
+            <button
+              onClick={saveSettings}
+              className="px-4 py-2 bg-primary text-white rounded"
+              type="button"
+            >
+              {t('settings.save')}
+            </button>
+          </div>
         </div>
       </div>
     </DashboardLayout>


### PR DESCRIPTION
## Summary
- add option to reset settings to defaults
- translate reset button label in English and Korean

## Testing
- `npm test --prefix frontend` *(fails: Failed to fetch `Noto Sans KR` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689d73c0e20c8327ba2dd260c6345a0a