### PR TITLE
Add current anomaly and per-device sensor chart placeholders

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -219,6 +219,8 @@
       "predictionRul": "Prediction (Remaining Useful Life)",
       "sensorData": "Sensor Data (Current & Vibration)",
       "realTimeSelected": "Real-Time Signal (selected)",
+      "current": "Current",
+      "vibration": "Vibration",
       "noData": "No data"
     },
     "connectingNotice": "Connecting to server…",

--- a/frontend/public/locales/ko/common.json
+++ b/frontend/public/locales/ko/common.json
@@ -219,6 +219,8 @@
       "predictionRul": "예측(잔여 수명)",
       "sensorData": "센서 데이터(전류·진동)",
       "realTimeSelected": "실시간 신호(선택)",
+      "current": "전류",
+      "vibration": "진동",
       "noData": "데이터 없음"
     },
     "connectingNotice": "서버에 연결 중입니다…",

--- a/frontend/public/mock-anomalies.json
+++ b/frontend/public/mock-anomalies.json
@@ -1,4 +1,4 @@
 [
   {"id": 1, "equipmentId": "L-CAHU-01R", "type": "vibration", "timestamp": "2024-01-01T10:00:00Z", "status": "open"},
-  {"id": 2, "equipmentId": "R-EF-05", "type": "temperature", "timestamp": "2024-01-02T11:00:00Z", "status": "resolved"}
+  {"id": 2, "equipmentId": "R-EF-05", "type": "current", "timestamp": "2024-01-02T11:00:00Z", "status": "resolved"}
 ]

--- a/frontend/src/app/monitoring/page.tsx
+++ b/frontend/src/app/monitoring/page.tsx
@@ -473,6 +473,63 @@ export default function MonitoringPage() {
           )}
         </div>
 
+        {machines && (
+          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {machines.map((m) => (
+              <ChartCard key={m.id} title={m.id}>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <h4 className="mb-2 text-sm font-medium">{t('charts.current')}</h4>
+                    {!filteredData.length ? (
+                      <div className="h-[160px] flex items-center justify-center text-slate-500">
+                        {t('charts.noData')}
+                      </div>
+                    ) : (
+                      <div className="h-[160px]">
+                        <ResponsiveContainer width="100%" height="100%">
+                          <LineChart
+                            data={filteredData}
+                            syncId="rt"
+                            margin={{ left: 12, right: 12, top: 8, bottom: 8 }}
+                          >
+                            <XAxis dataKey="time" tick={axisStyle} tickFormatter={xTick} />
+                            <YAxis tick={axisStyle} width={48} />
+                            <Tooltip labelFormatter={tooltipLabel} />
+                            <Line type="monotone" dataKey="current" stroke={colors.a} dot={false} />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <h4 className="mb-2 text-sm font-medium">{t('charts.vibration')}</h4>
+                    {!filteredData.length ? (
+                      <div className="h-[160px] flex items-center justify-center text-slate-500">
+                        {t('charts.noData')}
+                      </div>
+                    ) : (
+                      <div className="h-[160px]">
+                        <ResponsiveContainer width="100%" height="100%">
+                          <LineChart
+                            data={filteredData}
+                            syncId="rt"
+                            margin={{ left: 12, right: 12, top: 8, bottom: 8 }}
+                          >
+                            <XAxis dataKey="time" tick={axisStyle} tickFormatter={xTick} />
+                            <YAxis tick={axisStyle} width={48} />
+                            <Tooltip labelFormatter={tooltipLabel} />
+                            <Line type="monotone" dataKey="vibration" stroke={colors.ptr} dot={false} />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </ChartCard>
+            ))}
+          </div>
+        )}
+
         {/* 연결 상태 안내 */}
         {isConnecting && (
           <div className="mt-4 rounded-md bg-blue-50 px-3 py-2 text-sm text-blue-800 ring-1 ring-blue-200">


### PR DESCRIPTION
## Summary
- Replace sample temperature anomaly with current
- Add translation strings for current and vibration
- Show grid of per-device current and vibration charts on dashboard

## Testing
- `npm run lint` *(fails: Unexpected any, react/no-unescaped-entities)*
- `npm test` *(fails: Failed to fetch font file; Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d84c7c4208327b90322dddfd97168