### PR TITLE
Fix initial dashboard load and sidebar navigation speed

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,1 @@
-// src/app/page.tsx
-import { redirect } from "next/navigation";
-
-export default function Page() {
-  // 기본 대시보드 페이지로 이동
-  redirect("/monitoring");
-}
+export { default } from './monitoring/page';

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,8 +7,6 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
-
-const MotionLink = motion(Link);
 import {
   HomeIcon,
   ExclamationCircleIcon,
@@ -84,23 +82,21 @@ export default function Sidebar() {
         {navItems.map(({ href, label, icon: Icon }, index) => {
           const active = pathname === href || pathname.startsWith(`${href}/`);
           return (
-            <MotionLink
+            <Link
               key={href}
               href={href}
               ref={el => {
                 itemRefs.current[index] = el;
               }}
-                className={`group flex items-center gap-3 h-12 px-3 rounded-lg text-sm transition focus:outline-none focus:ring-2 focus:ring-accent ${
+              className={`group flex items-center gap-3 h-12 px-3 rounded-lg text-sm transition focus:outline-none focus:ring-2 focus:ring-accent ${
                 active ? 'bg-gray-800 font-semibold' : 'hover:bg-gray-800'
               }`}
               aria-current={active ? 'page' : undefined}
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
             >
               <Icon className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
               <span className={`${collapsed ? 'hidden' : 'flex-1'}`}>{t(label)}</span>
               {active && <span className="h-2 w-2 bg-accent rounded-full" />}
-            </MotionLink>
+            </Link>
           );
         })}
       </nav>


### PR DESCRIPTION
## Summary
- Render dashboard by default so the app opens directly to monitoring
- Simplify sidebar navigation links for faster, single-click transitions

## Testing
- `npm test` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc5cf5388327a60cf30d1732aad6