### PR TITLE
Add device search summaries with layout

### DIFF
--- a/frontend/src/__tests__/search.test.tsx
+++ b/frontend/src/__tests__/search.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import SearchPage from '@/app/search/page'
+import type { ReactNode } from 'react'
+
+jest.mock('@/components/DashboardLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/DeviceSensorPanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid="graph">graph</div>,
+}))
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams([["query", "L-DEF"]]),
+}))
+
+const mockDevices = [
+  { id: 'L-DEF-01', name: 'Line Device', type: 'Motor', status: 'Active' },
+  { id: 'B-123', name: 'Boiler', type: 'Boiler', status: 'Idle' },
+]
+
+describe('SearchPage', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(mockDevices) })
+    ) as jest.Mock
+  })
+
+  afterEach(() => {
+    ;(global.fetch as jest.Mock).mockRestore()
+  })
+
+  it('filters devices by query and shows matching results', async () => {
+    const client = new QueryClient()
+    render(
+      <QueryClientProvider client={client}>
+        <SearchPage />
+      </QueryClientProvider>
+    )
+    expect(await screen.findByText('Line Device')).toBeInTheDocument()
+    expect(screen.queryByText('Boiler')).not.toBeInTheDocument()
+  })
+})
+

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -3,36 +3,36 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import DashboardLayout from '@/components/DashboardLayout';
+import DeviceSearchResult from '@/components/DeviceSearchResult';
+import { useQuery } from '@tanstack/react-query';
+import { alertList } from '@/mockData';
 
-function Section({ title, items }: { title: string; items: string[] }) {
-  return (
-    <section className="bg-white rounded-lg shadow p-4">
-      <h3 className="text-sm font-semibold text-neutral-700 mb-2">{title}</h3>
-      {items.length === 0 ? (
-        <p className="text-neutral-500 text-sm">No results</p>
-      ) : (
-        <ul className="list-disc list-inside text-sm text-neutral-800">
-          {items.map((it, idx) => (
-            <li key={idx}>{it}</li>
-          ))}
-        </ul>
-      )}
-    </section>
-  );
+interface Device {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
 }
 
 export default function SearchPage() {
   const params = useSearchParams();
   const query = (params?.get('query') ?? '').trim();
 
-  const suggestions = useMemo(() => {
+  const { data: devices = [] } = useQuery<Device[]>({
+    queryKey: ['devices'],
+    queryFn: () => fetch('/mock-devices.json').then((r) => r.json()),
+    staleTime: 30000,
+    gcTime: 300000,
+  });
+
+  const filtered = useMemo(() => {
     if (!query) return [];
-    return [
-      `Try filtering by device: ${query}`,
-      `Search in alerts: ${query}`,
-      `Open device details: ${query}`,
-    ];
-  }, [query]);
+    return devices.filter(
+      (d) =>
+        d.name.toLowerCase().includes(query.toLowerCase()) ||
+        d.id.toLowerCase().includes(query.toLowerCase()),
+    );
+  }, [devices, query]);
 
   return (
     <DashboardLayout>
@@ -45,13 +45,22 @@ export default function SearchPage() {
         </div>
         {!query ? (
           <div className="bg-white rounded-lg shadow p-6 text-sm text-neutral-700">
-            Type a keyword in the header search to find devices, alerts and events.
+            Type a keyword in the header search to find devices, alerts and
+            events.
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="bg-white rounded-lg shadow p-6 text-sm text-neutral-700">
+            No devices found
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Section title="Devices" items={[]} />
-            <Section title="Alerts" items={[]} />
-            <Section title="Events" items={suggestions} />
+          <div className="space-y-4">
+            {filtered.map((device) => (
+              <DeviceSearchResult
+                key={device.id}
+                device={device}
+                alerts={alertList.filter((a) => a.device === device.id)}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/frontend/src/components/DeviceSearchResult.tsx
+++ b/frontend/src/components/DeviceSearchResult.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import DeviceSensorPanel from './DeviceSensorPanel'
+import type { AlertItem } from '@/mockData'
+
+interface Device {
+  id: string
+  name: string
+  type: string
+  status: string
+}
+
+interface Props {
+  device: Device
+  alerts: AlertItem[]
+}
+
+export default function DeviceSearchResult({ device, alerts }: Props) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4 md:flex md:gap-4">
+      <div className="md:w-1/2">
+        <DeviceSensorPanel deviceId={device.id} sensor="current" height={200} />
+      </div>
+      <div className="md:w-1/2 mt-4 md:mt-0 space-y-2">
+        <h3 className="text-lg font-semibold">{device.name}</h3>
+        <p className="text-sm text-neutral-600">ID: {device.id}</p>
+        <p className="text-sm text-neutral-600">Type: {device.type}</p>
+        <p className="text-sm text-neutral-600">Status: {device.status}</p>
+        <h4 className="font-medium mt-2">Alerts</h4>
+        {alerts.length === 0 ? (
+          <p className="text-sm text-neutral-500">No alerts</p>
+        ) : (
+          <ul className="list-disc list-inside text-sm">
+            {alerts.map((a) => (
+              <li key={a.id}>
+                <span className="font-medium">{a.type}</span> - {a.severity}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- show device summaries on search page including graphs and alerts
- add DeviceSearchResult component for graph-left layout
- cover filtering logic with unit test

## Testing
- `npm test` *(fails: Failed to fetch `Noto Sans KR` / `Roboto` from Google Fonts)*
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68abdb3dedb4832797928f774a2fac49