### PR TITLE
Add South Korea geodata fallback

### DIFF
--- a/frontend/src/geodata/southKoreaLow.ts
+++ b/frontend/src/geodata/southKoreaLow.ts
@@ -1,0 +1,2 @@
+import southKoreaLow from '@amcharts/amcharts4-geodata/southKoreaLow';
+export default southKoreaLow;


### PR DESCRIPTION
## Summary
- provide South Korea map data fallback by re-exporting amCharts' `southKoreaLow`

## Testing
- `npm run build` *(fails: Failed to fetch `Noto Sans KR`/`Roboto` from Google Fonts)*
- `npm test` *(fails: Failed to fetch `Noto Sans KR`/`Roboto` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68abf6b9f9288327b3ed7f477dc57cdb