### PR TITLE
Fix FTS page parsing and use local fonts

### DIFF
--- a/frontend/src/app/fts/page.tsx
+++ b/frontend/src/app/fts/page.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+'use client';
 
 /**
  * FTS (Follow‑the‑Sun) Call Desk — Next.js App Router (single‑file drop‑in)
@@ -351,7 +350,6 @@ function FactoryPills({ factories, selectedFactoryId, onSelect }: FactoryPillsPr
   )
 }
 
-function DirectoryList({ items }: { items: Factory[] }) {
 function DirectoryList({ items, getRegionLabel }: { items: Factory[]; getRegionLabel: (name: string) => string }) {
   const { t } = useTranslation('common')
   if (!items.length) {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,24 +1,18 @@
 // src/app/layout.tsx
 
 import type { Metadata } from 'next';
-import { Noto_Sans_KR, Roboto } from 'next/font/google';
 import QueryProvider from '@/components/QueryProvider';
 import Sidebar from '@/components/Sidebar';
 import I18nProvider from '@/components/I18nProvider';
 import LanguageListener from '@/components/LanguageListener';
 import './globals.css';
 
-const notoSans = Noto_Sans_KR({
-  weight: ['400', '700'],
-  subsets: ['latin'],
-  variable: '--font-noto-sans',
-});
-
-const roboto = Roboto({
-  weight: ['400', '500', '700'],
-  subsets: ['latin'],
-  variable: '--font-roboto',
-});
+// Preload fonts locally to avoid network fetch during build
+import '@fontsource/noto-sans-kr/400.css';
+import '@fontsource/noto-sans-kr/700.css';
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
 
 export const metadata: Metadata = {
   title: 'Factory PdM Monitoring Dashboard',
@@ -32,9 +26,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body
-        className={`${notoSans.variable} ${roboto.variable} antialiased bg-gray-100`}
-      >
+      <body className="antialiased bg-gray-100">
         <I18nProvider>
           <LanguageListener />
           <QueryProvider>


### PR DESCRIPTION
## Summary
- ensure FTS page is marked as client component and remove stray DirectoryList declaration
- preload local Roboto and Noto Sans KR fonts instead of fetching from Google

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: ESLint rule violations in src/app/fts/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0608ab848327bd8d6e773dae39ca