### PR TITLE
Improve FTS factory search and layout

### DIFF
--- a/frontend/src/app/fts/page.tsx
+++ b/frontend/src/app/fts/page.tsx
@@ -485,7 +485,10 @@ export default function FTSPage() {
     const q = search.trim().toLowerCase()
     if (!q) return factoryScoped
     return factoryScoped.filter((f) =>
-      getFactoryName(f).toLowerCase().includes(q) ||
+      // match against both Korean and English names regardless of UI language
+      Object.values(f.name)
+        .map((n) => n.toLowerCase())
+        .some((n) => n.includes(q)) ||
       f.manager.toLowerCase().includes(q) ||
       f.phone.toLowerCase().includes(q)
     )
@@ -517,10 +520,10 @@ export default function FTSPage() {
 
         {/* Controls */}
         <div className="mb-5 grid grid-cols-12 gap-4">
-          <div className="col-span-12 lg:col-span-7">
+          <div className="col-span-12 lg:col-span-6">
             <SearchBox value={search} onChange={setSearch} placeholder={t('fts.searchPlaceholder')} />
           </div>
-          <div className="col-span-12 lg:col-span-5">
+          <div className="col-span-12 lg:col-span-6">
             <div className="rounded-2xl border border-gray-100 p-3 shadow-sm">
               <div className="mb-2 text-xs font-semibold text-gray-600">{t('fts.factoryShortcut')}</div>
               <FactoryPills


### PR DESCRIPTION
## Summary
- allow cross-language factory name search on the FTS page
- align search and shortcut cards with map and contact card widths

## Testing
- `npm run lint` *(fails: Unexpected any in api routes and page.tsx)*
- `npm test` *(fails: Unexpected any in api routes and page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2277c2108327a1baff665fd5657a