### PR TITLE
fix: ensure settings page text visible

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -233,7 +233,7 @@ export default function SettingsPage() {
 
           <div className="flex items-center gap-2">
             <Button
-              className="border border-primary bg-transparent text-primary hover:bg-primary/5"
+              className="border border-blue-600 bg-transparent text-blue-600 hover:bg-blue-50"
               onClick={resetSettings}
               type="button"
             >
@@ -293,7 +293,7 @@ export default function SettingsPage() {
                       className={[
                         'w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm',
                         isActive
-                          ? 'bg-primary text-white'
+                          ? 'bg-blue-600 text-white'
                           : 'hover:bg-gray-50 text-gray-700',
                       ].join(' ')}
                     >

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ export const Button: FC<ButtonHTMLAttributes<HTMLButtonElement>> = ({
   ...props
 }) => (
   <button
-    className={`bg-primary text-white py-2 px-4 rounded hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-accent ${className}`}
+    className={`bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-accent ${className}`}
     {...props}
   >
     {children}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -18,7 +18,7 @@ export const CardHeader: FC<{ children: ReactNode; className?: string }> = ({
   className = '',
 }) => (
   <div
-    className={`px-6 py-4 border-b border-gray-200 bg-primary text-white rounded-t-lg ${className}`}
+    className={`px-6 py-4 border-b border-gray-200 bg-blue-600 text-white rounded-t-lg ${className}`}
   >
     {children}
   </div>


### PR DESCRIPTION
## Summary
- replace custom primary color usage with Tailwind blue tones for buttons, card headers, and navigation
- ensure settings reset button and sidebar selection use visible text

## Testing
- `npm test` *(fails: 'unique' is defined but never used, Unexpected any, require imports forbidden, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac35b8dde083278767468cd1a97eb4