### PR TITLE
tune settings theme and button visibility

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -119,6 +119,7 @@
     "advanced": {
       "beta": "Enable beta features",
       "apiKey": "API Key",
+      "copy": "Copy",
       "regenerate": "Regenerate"
     },
     "about": {

--- a/frontend/public/locales/ko/common.json
+++ b/frontend/public/locales/ko/common.json
@@ -119,6 +119,7 @@
     "advanced": {
       "beta": "베타 기능 사용",
       "apiKey": "API 키",
+      "copy": "복사",
       "regenerate": "재발급"
     },
     "about": {

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -233,7 +233,7 @@ export default function SettingsPage() {
 
           <div className="flex items-center gap-2">
             <Button
-              className="border border-blue-600 bg-transparent text-blue-600 hover:bg-blue-50"
+              className="border border-blue-500 bg-transparent text-blue-500 hover:bg-blue-50"
               onClick={resetSettings}
               type="button"
             >
@@ -293,7 +293,7 @@ export default function SettingsPage() {
                       className={[
                         'w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm',
                         isActive
-                          ? 'bg-blue-600 text-white'
+                          ? 'bg-blue-500 text-white'
                           : 'hover:bg-gray-50 text-gray-700',
                       ].join(' ')}
                     >
@@ -546,11 +546,12 @@ export default function SettingsPage() {
                         <Input id="apiKey" value={apiKey} readOnly className="flex-1" />
                         <Button
                           type="button"
-                          className="bg-white text-gray-700 border border-gray-200 hover:bg-gray-50"
+                          className="bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 flex items-center gap-1"
                           onClick={copyApiKey}
                           title={t('settings.advanced.copy', { defaultValue: 'Copy' }) as string}
                         >
                           <CopyIcon className="h-4 w-4" />
+                          {t('settings.advanced.copy', { defaultValue: 'Copy' })}
                         </Button>
                         <Button type="button" onClick={regenerateApiKey}>
                           {t('settings.advanced.regenerate')}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ export const Button: FC<ButtonHTMLAttributes<HTMLButtonElement>> = ({
   ...props
 }) => (
   <button
-    className={`bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-accent ${className}`}
+    className={`bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-accent ${className}`}
     {...props}
   >
     {children}


### PR DESCRIPTION
## Summary
- soften default button and navigation blues for a gentler settings look
- fix reset button styling and show a clear label for copying the API key
- add missing translations for the API key copy action

## Testing
- `npm test` *(fails: 'unique' is defined but never used, Unexpected any, A `require()` style import is forbidden, React Hook dependencies warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac38c73e7c83278d14d954d4d1de92