### PR TITLE
style: align accents with primary blue

### DIFF
--- a/backend/docker/grafana/dashboards/sensor-dashboard-main.json
+++ b/backend/docker/grafana/dashboards/sensor-dashboard-main.json
@@ -74,7 +74,7 @@
         "overrides": [
           {
             "matcher": {"id": "byName", "options": "x"},
-            "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]
+              "properties": [{"id": "color", "value": {"fixedColor": "#3a6ea5", "mode": "fixed"}}]
           },
           {
             "matcher": {"id": "byName", "options": "y"},
@@ -144,7 +144,7 @@
         "overrides": [
           {
             "matcher": {"id": "byName", "options": "vibration"},
-            "properties": [{"id": "color", "value": {"fixedColor": "purple", "mode": "fixed"}}]
+              "properties": [{"id": "color", "value": {"fixedColor": "#3a6ea5", "mode": "fixed"}}]
           }
         ]
       },

--- a/backend/docker/grafana/dashboards/sensor-dashboard.json
+++ b/backend/docker/grafana/dashboards/sensor-dashboard.json
@@ -74,7 +74,7 @@
         "overrides": [
           {
             "matcher": {"id": "byName", "options": "x"},
-            "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]
+              "properties": [{"id": "color", "value": {"fixedColor": "#3a6ea5", "mode": "fixed"}}]
           },
           {
             "matcher": {"id": "byName", "options": "y"},
@@ -144,7 +144,7 @@
         "overrides": [
           {
             "matcher": {"id": "byName", "options": "vibration"},
-            "properties": [{"id": "color", "value": {"fixedColor": "purple", "mode": "fixed"}}]
+              "properties": [{"id": "color", "value": {"fixedColor": "#3a6ea5", "mode": "fixed"}}]
           }
         ]
       },

--- a/frontend/src/app/fts/page.tsx
+++ b/frontend/src/app/fts/page.tsx
@@ -324,7 +324,7 @@ function CountryToggle({ value, onChange }: CountryToggleProps) {
             type="button"
             className={cx(
               'px-4 py-2 text-sm font-medium transition',
-              active ? 'bg-violet-600 text-white' : 'hover:bg-violet-50 text-gray-700'
+              active ? 'bg-primary text-white' : 'hover:bg-primary/10 text-gray-700'
             )}
             onClick={() => onChange(code as Country)}
           >
@@ -348,7 +348,7 @@ function SearchBox({ value, onChange, placeholder }: SearchBoxProps) {
     <div className="relative w-full">
       <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
       <input
-        className="w-full rounded-full border border-gray-200 bg-white pl-10 pr-10 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none"
+        className="w-full rounded-full border border-gray-200 bg-white pl-10 pr-10 py-2 text-sm shadow-sm focus:border-primary focus:outline-none"
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -384,7 +384,7 @@ function FactoryPills({ factories, selectedFactoryId, onSelect, getFactoryName }
         type="button"
         className={cx(
           'px-3 py-1.5 rounded-full border text-xs font-medium',
-          !selectedFactoryId ? 'bg-violet-600 border-violet-600 text-white' : 'hover:bg-gray-50 border-gray-200'
+          !selectedFactoryId ? 'bg-primary border-primary text-white' : 'hover:bg-gray-50 border-gray-200'
         )}
         onClick={() => onSelect(null)}
       >
@@ -396,7 +396,7 @@ function FactoryPills({ factories, selectedFactoryId, onSelect, getFactoryName }
           type="button"
           className={cx(
             'px-3 py-1.5 rounded-full border text-xs font-medium transition',
-            selectedFactoryId === f.id ? 'bg-violet-600 border-violet-600 text-white' : 'hover:bg-gray-50 border-gray-200'
+            selectedFactoryId === f.id ? 'bg-primary border-primary text-white' : 'hover:bg-gray-50 border-gray-200'
           )}
           onClick={() => onSelect(f.id)}
           title={getFactoryName(f)}
@@ -507,8 +507,8 @@ export default function FTSPage() {
         {/* Header */}
         <div className="mb-6 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100">
-              <Phone className="h-5 w-5 text-violet-700" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+              <Phone className="h-5 w-5 text-primary" />
             </div>
             <div>
               <h1 className="text-xl font-semibold">{t('fts.title')}</h1>

--- a/frontend/src/app/help/page.tsx
+++ b/frontend/src/app/help/page.tsx
@@ -151,7 +151,7 @@ function SystemStatusCard() {
         </div>
         {ts && <div className="mt-3 text-xs text-gray-500">업데이트: {ts}</div>}
         <div className="mt-3 text-xs">
-          <Link href="/status" className="inline-flex items-center gap-1 text-violet-700 hover:underline">
+          <Link href="/status" className="inline-flex items-center gap-1 text-primary hover:underline">
             자세히 보기 <ExternalLink className="h-3.5 w-3.5"/>
           </Link>
         </div>
@@ -314,8 +314,8 @@ export default function HelpPage() {
         {/* Header */}
         <div className="mb-6 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100">
-              <LifeBuoy className="h-5 w-5 text-violet-700" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+              <LifeBuoy className="h-5 w-5 text-primary" />
             </div>
             <div>
               <h1 className="text-2xl font-semibold">{t('help.title', { defaultValue: 'Help Center' })}</h1>
@@ -341,9 +341,9 @@ export default function HelpPage() {
               </CardHeader>
               <CardContent>
                 <ul className="list-disc pl-5 space-y-2 text-sm">
-                  <li><Link href={process.env.NEXT_PUBLIC_DOCS_URL || '#'} className="text-violet-700 hover:underline">제품 문서</Link></li>
-                  <li><Link href="/fts" className="text-violet-700 hover:underline">FTS 연락처</Link></li>
-                  <li><Link href="/settings" className="text-violet-700 hover:underline">설정</Link></li>
+                    <li><Link href={process.env.NEXT_PUBLIC_DOCS_URL || '#'} className="text-primary hover:underline">제품 문서</Link></li>
+                    <li><Link href="/fts" className="text-primary hover:underline">FTS 연락처</Link></li>
+                    <li><Link href="/settings" className="text-primary hover:underline">설정</Link></li>
                 </ul>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- refactor FTS call page to use primary blue on country toggle, search, factory pills, and header icon
- update Help page links and badge icons to use primary blue styling
- switch Grafana sensor dashboards to fixed `#3a6ea5` primary blue for main series

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3f21e2c48327b16b87f1c563eafc